### PR TITLE
Makefile: use `$(MAKE -C) instead of cd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ mgl_colorize: blackt $(OBJ)
 	$(CXX) $(ODIR)/mgl_colorize.o -o mgl_colorize $(CXXFLAGS)
 
 blackt:
-	cd ./blackt && $(MAKE) && cd $(CURDIR)
+	$(MAKE) -C blackt
 
 .PHONY: blackt clean cleanme install
 
@@ -103,7 +103,7 @@ cleanme:
 
 # Clean mgltools and libraries
 clean: cleanme
-	cd ./blackt && $(MAKE) clean && cd $(CURDIR)
+	$(MAKE) -C blackt clean
 
 install: all
 	$(INSTALL) -d $(BINDIR)


### PR DESCRIPTION
Make is extremely space unsafe in variable names, so if the working directory contains spaces, the `cd $(CURDIR)` would fail. `$(MAKE) -C` builds the subdirectory fine and doesn't strip over spaces though!