### PR TITLE
mgl_colorize: print colour values as hex

### DIFF
--- a/src/mgl_colorize.cpp
+++ b/src/mgl_colorize.cpp
@@ -31,8 +31,8 @@ int findColorIndex(vector<TColor>& palette, TColor color) {
   }
   
   cerr << "Color not in palette: "
-    << color.r() << "," << color.g() << ","
-    << color.b() << "," << color.a() << endl;
+    << hex << (int)color.r() << "," << hex << (int)color.g() << ","
+    << hex << (int)color.b() << "," << hex << (int)color.a() << endl;
   exit(1);
 }
 


### PR DESCRIPTION
Currently they're printed as a character at the colour's ASCII ordinal.