### PR TITLE
csv_utf8: support escape characters for non-ASCII chars

### DIFF
--- a/src/csv_utf8.cpp
+++ b/src/csv_utf8.cpp
@@ -72,6 +72,14 @@ int readCsvFieldToBigChars(BigChars& chars, int pos, BigChars& dst) {
     if (chars[i] == 0x201D) {
       dst.push_back('"');
     }
+    // \xFF format
+    else if (chars[i] == '\\' && chars[i+1] == 'x') {
+      char ordinal[3];
+      sprintf(ordinal, "%c%c", chars[i+2], chars[i+3]);
+      printf("%s\n", ordinal);
+      dst.push_back((char)std::stoul(ordinal, nullptr, 16));
+      i += 3;
+    }
     else {
       dst.push_back(chars[i]);
     }


### PR DESCRIPTION
This uses the \xFF format supported by Ruby and Python, among others.

I found this useful with `mgl_str_insr` when I wanted to refer to characters outside the ASCII region, but within the 1-byte region. For example, I added a few new glyphs to the 8x8 font to replace characters in the now-unused kana sets; this escape format let me refer to it as something like `\x81\x82\x83\x84`, which was a lot less error-prone than trying to include those bytes literally.