### PR TITLE
Support special characters

### DIFF
--- a/libsat/src/mgl/csv_utf8.cpp
+++ b/libsat/src/mgl/csv_utf8.cpp
@@ -94,6 +94,12 @@ namespace Sat {
       if (chars[i] == 0x201D) {
         dst.push_back('"');
       }
+      // UTF-8 ellipsis
+      else if (chars[i] == 0x2026) {
+        dst.push_back('.');
+        dst.push_back('.');
+        dst.push_back('.');
+      }
       // \xFF format
       else if (chars[i] == '\\' && chars[i+1] == 'x') {
         char ordinal[3];


### PR DESCRIPTION
This adds support for parsing the UTF-8 ellipsis (`…`) into a normal ASCII one. It's pretty likely that users' keyboards are going to have used these when they didn't mean to type them.

~~I've also fixed up a bug in the `\x` literal parsing, where it would accidentally eat the subsequent character too.~~ Ignore this part, that wasn't actually a bug!