### PR TITLE
Add bounds check for \x sequences in CSV reader

### DIFF
--- a/libsat/src/mgl/csv_utf8.cpp
+++ b/libsat/src/mgl/csv_utf8.cpp
@@ -101,7 +101,9 @@ namespace Sat {
         dst.push_back('.');
       }
       // \xFF format
-      else if (chars[i] == '\\' && chars[i+1] == 'x') {
+      else if ((i <= endpos - 4)
+               && (chars[i] == '\\')
+               && (chars[i+1] == 'x')) {
         char ordinal[3];
         sprintf(ordinal, "%c%c", chars[i+2], chars[i+3]);
         printf("%s\n", ordinal);


### PR DESCRIPTION
Fixes a theoretical problem where the \xNN hex code parser would access out-of-bounds memory for certain unlikely inputs like a backslash at the very end of a row.